### PR TITLE
Correct bucket endpoint on step 4

### DIFF
--- a/WebApplication/1_StaticWebHosting/README.md
+++ b/WebApplication/1_StaticWebHosting/README.md
@@ -192,7 +192,7 @@ See [this example](http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket
 
 ### 4. Enable Website Hosting
 
-By default objects in an S3 bucket are available via URLs with the structure `http://<Regional-S3-prefix>.amazonaws.com/<bucket-name>/<object-key>`. In order to serve assets from the root URL (e.g. /index.html), you'll need to enable website hosting on the bucket. This will make your objects available at the AWS Region-specific website endpoint of the bucket: `<bucket-name>.s3-website-<AWS-region>.amazonaws.com`
+By default objects in an S3 bucket are available via URLs with the structure `http://<Regional-S3-prefix>.amazonaws.com/<bucket-name>/<object-key>`. In order to serve assets from the root URL (e.g. /index.html), you'll need to enable website hosting on the bucket. This will make your objects available at the AWS Region-specific website endpoint of the bucket: `<bucket-name>.s3-website.<AWS-region>.amazonaws.com`
 
 You can also use a custom domain for your website. For example http://www.wildrydes.com is hosted on S3. Setting up a custom domain is not covered in this workshop, but you can find detailed instructions in our [documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html).
 


### PR DESCRIPTION
By replacing the <bucket-name> and <AWS-region> on the current URL <bucket-name>.s3-website-<AWS-region>.amazonaws.com, the user will get an error because it doesn't exist, the correct URL should be <bucket-name>.s3-website.<AWS-region>.amazonaws.com