### PR TITLE
`invokeUrl` should be empty by default

### DIFF
--- a/WebApplication/2_UserManagement/user-management.yaml
+++ b/WebApplication/2_UserManagement/user-management.yaml
@@ -124,7 +124,7 @@ Resources:
                   region: '%s', // e.g. us-east-2
               },
               api: {
-                  invokeUrl: 'Base URL of your API including the stage', // e.g. https://rc7nyt4tql.execute-api.us-west-2.amazonaws.com/prod'
+                  invokeUrl: '', // Base URL of your API including the stage, e.g. 'https://rc7nyt4tql.execute-api.us-west-2.amazonaws.com/prod'
               }
           };
               """


### PR DESCRIPTION
The `invokeUrl` parameter should be empty by default to make it consistent with the UX described [here](https://github.com/aws-samples/aws-serverless-workshops/tree/master/WebApplication/2_UserManagement#implementation-validation).

If `invokeUrl` is not empty, you won't be shown this message:

> This page is not functional yet because there is no API invoke URL configured in /js/config.js.