### PR TITLE
Improved `invokeUrl` injection (w/o placeholder)

### DIFF
--- a/WebApplication/4_RESTfulAPIs/backend-api.yaml
+++ b/WebApplication/4_RESTfulAPIs/backend-api.yaml
@@ -378,7 +378,7 @@ Resources:
             bucket = properties['Bucket']
             config_object = s3.Object(bucket, 'js/config.js').get()
             config_data = config_object["Body"].read()
-            config_data = config_data.replace("Base URL of your API including the stage", properties["InvokeUrl"])
+            config_data = config_data.replace("invokeUrl: ''", "invokeUrl: '%s'" % properties["InvokeUrl"])
             config = s3.Object(bucket,'js/config.js')
             config.put(Body=config_data)
             return cfnresponse.SUCCESS, None


### PR DESCRIPTION
Based on #122, the `invokeUrl` config param should be empty.

This PR (to be merged together or into #122) makes sure that we replace the empty value correctly, although it still counts on an (empty) placeholder.

Ideally, the config file should be replaced with a proper JSON object, so that we could simply:

```python
config_json = json.loads(config_data)
config_json['invokeUrl'] = properties["InvokeUrl"]
config_data = json.dumps(config_json)
```