### PR TITLE
Removed extra apostrophe to save the public time

### DIFF
--- a/WebApplication/1_StaticWebHosting/website/js/config.js
+++ b/WebApplication/1_StaticWebHosting/website/js/config.js
@@ -5,6 +5,6 @@ window._config = {
         region: '' // e.g. us-east-2
     },
     api: {
-        invokeUrl: '' // e.g. https://rc7nyt4tql.execute-api.us-west-2.amazonaws.com/prod',
+        invokeUrl: '' // e.g. https://rc7nyt4tql.execute-api.us-west-2.amazonaws.com/prod,
     }
 };


### PR DESCRIPTION
After a bit of re-configuring due to the website not reacting properly (had to be something `.js`), I was brought to several dead-ends. After ~45min, I noticed an extra apostrophe in `config.js` Line 8, in the commented example for `invokeUrl`. Some like me, may test the `e.g.`; or when getting rid of the `e.g.`, may accidentally leave the stray apostrophe. `config.js` is used repeatedly for the serverless WebApplication project, so there is a potential for repeated mistakes. Though miniscule, this change could save time and frustration for others like myself.