### PR TITLE
Change register link to relative path

### DIFF
--- a/WebApplication/1_StaticWebHosting/website/index.html
+++ b/WebApplication/1_StaticWebHosting/website/index.html
@@ -25,7 +25,7 @@
       </ul>
     </nav>
     <button type="button" class="btn-menu"><span>Menu</span></button>
-    <a class="home-button" href="/register.html">Giddy Up!</a>
+    <a class="home-button" href="register.html">Giddy Up!</a>
   </header>
 
   <section class="home-about">


### PR DESCRIPTION
This is to make the registration link work if ever they choose to deploy the static website in their own S3 folders.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
