### PR TITLE
Bump AWS Lambda functions version to NodeJS 8.10

### DIFF
--- a/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: SXR API Stack for failover region.
 
 Resources:
-  
+
   TicketServiceAPI:
     Type: AWS::Serverless::Api
     Properties:
@@ -95,12 +95,12 @@ Resources:
                 passthroughBehavior: "when_no_match"
                 type: "mock"
         swagger: '2.0'
-  
+
   TicketGetFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -121,12 +121,12 @@ Resources:
             Path: /ticket
             Method: get
             RestApiId: !Ref TicketServiceAPI
-  
+
   TicketPostFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -146,12 +146,12 @@ Resources:
             Path: /ticket
             Method: post
             RestApiId: !Ref TicketServiceAPI
-  
+
   HealthFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -172,7 +172,7 @@ Resources:
             Path: /health
             Method: get
             RestApiId: !Ref TicketServiceAPI
-  
+
 Outputs:
   ApiUrl:
     Description: URL of your API endpoint

--- a/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 Description: SXR API Stack for failover region.
 
 Resources:
-  
+
   TicketServiceAPI:
     Type: AWS::Serverless::Api
     Properties:
@@ -95,12 +95,12 @@ Resources:
                 passthroughBehavior: "when_no_match"
                 type: "mock"
         swagger: '2.0'
-  
+
   TicketGetFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -121,12 +121,12 @@ Resources:
             Path: /ticket
             Method: get
             RestApiId: !Ref TicketServiceAPI
-  
+
   TicketPostFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -146,12 +146,12 @@ Resources:
             Path: /ticket
             Method: post
             RestApiId: !Ref TicketServiceAPI
-  
+
   HealthFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -172,7 +172,7 @@ Resources:
             Path: /health
             Method: get
             RestApiId: !Ref TicketServiceAPI
-  
+
   DynamoDBTicketTable:
    Type: AWS::DynamoDB::Table
    Properties:

--- a/WebApplication/5_OAuth/prerequisites.yaml
+++ b/WebApplication/5_OAuth/prerequisites.yaml
@@ -332,45 +332,45 @@ Resources:
         -
           AttributeName: RideId
           KeyType: HASH
-      ProvisionedThroughput: 
+      ProvisionedThroughput:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
 
   RequestUnicornExecutionRole:
     Type: AWS::IAM::Role
-    Properties: 
+    Properties:
       RoleName: WildRydesLambda
-      AssumeRolePolicyDocument: 
+      AssumeRolePolicyDocument:
         Version: 2012-10-17
-        Statement: 
-          - 
+        Statement:
+          -
             Effect: Allow
-            Principal: 
-              Service: 
+            Principal:
+              Service:
                 - lambda.amazonaws.com
-            Action: 
+            Action:
               - "sts:AssumeRole"
       Path: "/wildrydes/"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      Policies: 
-        - 
+      Policies:
+        -
           PolicyName: PutRidePolicy
-          PolicyDocument: 
+          PolicyDocument:
             Version: 2012-10-17
-            Statement: 
-              - 
+            Statement:
+              -
                 Effect: Allow
-                Action: 
+                Action:
                   - dynamodb:PutItem
                   - dynamodb:Scan
                 Resource: !GetAtt RidesTable.Arn
-  
+
   RequestUnicornFunction:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: RequestUnicorn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Role: !GetAtt RequestUnicornExecutionRole.Arn
       Timeout: 5
       MemorySize: 128
@@ -529,7 +529,7 @@ Resources:
                     statusCode: 200
                     responseParameters:
                       method.response.header.Access-Control-Allow-Origin: "'*'"
-                uri: 
+                uri:
                   Fn::Join:
                     - ""
                     - - "arn:aws:apigateway:"
@@ -590,7 +590,7 @@ Resources:
     Properties:
       Description: Prod deployment for wild Rydes API
       RestApiId: !Ref WildRydesApi
-      StageName: prod         
+      StageName: prod
 
   WildRydesFunctionPermissions:
     Type: AWS::Lambda::Permission
@@ -622,7 +622,7 @@ Resources:
             - ".execute-api."
             - !Ref AWS::Region
             - ".amazonaws.com/prod"
-      
+
   UpdateApiConfigFunction:
     Type: AWS::Lambda::Function
     DependsOn: UpdateCognitoConfigFunction


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Update remaining AWS Lambda functions from nodejs6.10 to nodejs8.10 in the MultiRegion and WebApplication modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
