### PR TITLE
Addig 3rd party workshop links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ This repository contains a collection of workshops and other hands on content th
 - [**Multi Region**](MultiRegion) - This workshop shows you how to build a serverless ticketing system that is replicated across two regions and provides automatic failover in the event of a disaster. You will learn the basics of deploying AWS Lambda functions, exposing them via API Gateway, and configuring replication using Route53 and DynamoDB streams.
 
 - [**Security**](https://github.com/aws-samples/aws-serverless-security-workshop) - This workshop shows you techniques to secure a serverless application built with AWS Lambda, Amazon API Gateway and RDS Aurora. We will cover AWS services and features you can leverage to improve the security of a serverless applications in 5 domains: identity & access management, infrastructure, data, code, and logging & monitoring.
+
+
+# Third Party Workshops
+
+The following workshops are created and maintained by third parties and explore a variety of other topics and tools related to serverless development on AWS.
+
+- [**HERE Geocoding and Routing Extensions**](https://github.com/heremaps/devrel-workshops/tree/master/aws-serverless) - These extensions to the [**Web Application**](WebApplication) and [**Data Processing**](https://dataprocessing.wildrydes.com) workshops walk through how to enhance the base applications with geocoding and advanced routing features. You'll see how to launch applications from the AWS Serverless Application Repository and integrate these components into the existing architectures. You'll need to complete the primary Web Application or Data Processing workshop from this repository before starting the extensions.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a section to the list of follow on workshops to highlight additional 3rd party workshops built by AWS Partners.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
