### PR TITLE
fixed syntax error AWSXRayDaemonWriteAccess policy in CF template dev…

### DIFF
--- a/DevOps/3_XRay/uni-api/template.yml
+++ b/DevOps/3_XRay/uni-api/template.yml
@@ -125,5 +125,5 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
-        -  arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
       PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/CodeStar_${ProjectId}_PermissionsBoundary'


### PR DESCRIPTION
devops lab3, CF template syntax error

*Issue #, if available:*
the Lambda IAM role didn't get Xray Policy AWSXRayDaemonWriteAccess

*Description of changes:*
removed one extra space

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
