### PR TITLE
Step-by-step missing changing IAM Role to allow reads from DynamoDB table

### DIFF
--- a/WebApplication/5_OAuth/README.md
+++ b/WebApplication/5_OAuth/README.md
@@ -49,6 +49,12 @@ Use the AWS Lambda console to create a new Lambda function called **ListUnicornR
 
 Make sure to configure your function to use the `WildRydesLambda` IAM role you created in module 2 of this workshop.
 
+> `WildRydesLambda` role need to be updated to perform read-only operations in DynamoDB, along with the `PutItem` you had set in module 2.
+
+<details>
+## TODO 
+</details>
+
 <details>
 <summary><strong>Step-by-step instructions (expand for details)</strong></summary><p>
 


### PR DESCRIPTION
**WIP** 

*Issue #, if available:*

*Description of changes:*
Customers that wanted to follow step-by-step instructions, instead of launching the corresponding CloudFormation template, will figure out later than appropriate that`WildRydesLambda` IAM Role does not allow reading from DynamoDB table that stores unicorn requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
