### PR TITLE
Define runtime so CodeBuild does not break.

### DIFF
--- a/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
+++ b/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+        nodejs: 8
     commands:
       - npm install
 

--- a/DevOps/3_XRay/uni-api/buildspec.yml
+++ b/DevOps/3_XRay/uni-api/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
  
 phases:
   install:
+    runtime-versions:
+        nodejs: 8
     commands:
       # Install dependencies needed for running tests
       - npm install


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding runtime so as to not get "runtime not defined" error in CodeBuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Might want to consider doing node 10 instead**
