### PR TITLE
Run npm install in app directory

### DIFF
--- a/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
+++ b/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
@@ -3,7 +3,9 @@ version: 0.2
 phases:
   install:
     commands:
+      - cd app
       - npm install
+      - cd ..
 
       # Upgrade AWS CLI to the latest version
       - pip install --upgrade awscli

--- a/DevOps/3_XRay/uni-api/buildspec.yml
+++ b/DevOps/3_XRay/uni-api/buildspec.yml
@@ -4,7 +4,9 @@ phases:
   install:
     commands:
       # Install dependencies needed for running tests
+      - cd app
       - npm install
+      - cd ..
 
       # Upgrade AWS CLI to the latest version
       - pip install --upgrade awscli


### PR DESCRIPTION

*Description of changes:*

`aws cloudformation package` will take the dependencies within the `app` folder. However, the current buildpsec installs those dependencies in the root folder, which makes the Lambda function fail despite being deploy (due to lack of dependencies)

This PR fixes that by cd'ing into the directory prior to npm install, and then cd'ing out. If there is a more elegant way of achieving the same result, please let me know.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
