### PR TITLE
Fix intermittent dependency error in X-Ray lab

### DIFF
--- a/DevOps/3_XRay/README.md
+++ b/DevOps/3_XRay/README.md
@@ -137,9 +137,27 @@ After the repository has been seeded, it will start a pipeline execution.  Monit
 ![Pipeline Complete](images/codestar-3.png)
 </details>
 
+### 4. Turn on Function Tracing
+
+Open the `uni-api/template.yml` and delete the `#` symbols on lines that say `#Tracing: Active`. This changes us from the default (no tracing) to enabling trace collection for our functions.
+
+### 5. Commit the change to local Git repository
+
+1. Using your Git client, add the local changes to the Git index, and commit with a message.  For example:
+
+    ```
+    git add -u
+    git commit -m "Fix bug"
+    ```
+
+1. Using your Git client, push the Git repository updates to the origin.  For example:
+
+    ```
+    git push origin
+    ```
 
 
-### 4. Exercise List Unicorns API Method
+### 6. Exercise List Unicorns API Method
 
 **Goal:** Use the CodeStar Console to find the Application Endpoint, and use your browser to test the "/unicorns" list resource.
 

--- a/DevOps/3_XRay/uni-api/template.yml
+++ b/DevOps/3_XRay/uni-api/template.yml
@@ -35,7 +35,7 @@ Resources:
       Handler: read.lambda_handler
       Description: View Unicorn by name
       Timeout: 10
-      Tracing: Active
+      #Tracing: Active
       Events:
         GET:
           Type: Api
@@ -56,7 +56,7 @@ Resources:
       Handler: list.lambda_handler
       Description: List Unicorns
       Timeout: 10
-      Tracing: Active
+      #Tracing: Active
       Events:
         GET:
           Type: Api
@@ -77,7 +77,7 @@ Resources:
       Handler: update.lambda_handler
       Description: Update Unicorn
       Timeout: 10
-      Tracing: Active
+      #Tracing: Active
       Events:
         PUT:
           Type: Api
@@ -98,7 +98,7 @@ Resources:
       Handler: delete.lambda_handler
       Description: Delete Unicorn
       Timeout: 10
-      Tracing: Active
+      #Tracing: Active
       Events:
         DELETE:
           Type: Api


### PR DESCRIPTION
The X-Ray section of the DevOps workshop fails intermittently. This is
because there's no direct dependency on the IAM update and the
`AWS::Serverless::Function` tracing setting. This means that sometimes
Lambdas fail to create, and requires that you either retry updates until
they succeed (ew) or:

1. delete the `Tracing: Active` lines
2. deploy
3. revert that change
4. deploy again

This change adds a segment where users activate function tracing *after*
populating the `uni-api` repo for X-Ray, so the first stack update adds
the IAM role and then the students add the tracing config in a second
update. This avoids the intermittent failure.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
