### PR TITLE
Fix bug with npm postinstall via buildspec.yml by changing to 'npm in…

### DIFF
--- a/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
+++ b/DevOps/2_ContinuousDeliveryPipeline/uni-api/buildspec.yml
@@ -3,6 +3,10 @@ version: 0.2
 phases:
   install:
     commands:
+      # Install application dependencies
+      - npm install --prefix app
+
+      # Install dependencies needed for running tests
       - npm install
 
       # Upgrade AWS CLI to the latest version

--- a/DevOps/2_ContinuousDeliveryPipeline/uni-api/package.json
+++ b/DevOps/2_ContinuousDeliveryPipeline/uni-api/package.json
@@ -5,9 +5,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {},
-  "scripts": {
-    "postinstall": "cd app && npm install"
-  },
+  "scripts": {},
   "devDependencies": {
     "mocha": "^4.0.1",
     "proxyquire": "^1.8.0"

--- a/DevOps/3_XRay/uni-api/app/package-lock.json
+++ b/DevOps/3_XRay/uni-api/app/package-lock.json
@@ -1,0 +1,242 @@
+{
+  "name": "uni-api",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
+    },
+    "atomic-batcher": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
+      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+    },
+    "aws-sdk": {
+      "version": "2.543.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.543.0.tgz",
+      "integrity": "sha512-ABHsA4W7LLYnTBCgtbTt0NF7+66nMCtdcJuAn30+RGzF0bOw3lCguqzootFrMlIOXklddQFJ9kKTXd+p/+uCVQ==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "aws-xray-sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk/-/aws-xray-sdk-1.3.0.tgz",
+      "integrity": "sha512-9oi5gOwzNGy5XyG3bI5hazDkGAaDKsPZTQBu0mrabehIrhT5JbLwIMsxcg0pKG2z1MiY/vj6cf537n2QXkXQKg==",
+      "requires": {
+        "aws-xray-sdk-core": "^1.3.0",
+        "aws-xray-sdk-express": "^1.3.0",
+        "aws-xray-sdk-mysql": "^1.3.0",
+        "aws-xray-sdk-postgres": "^1.3.0",
+        "pkginfo": "^0.4.0"
+      }
+    },
+    "aws-xray-sdk-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-1.3.0.tgz",
+      "integrity": "sha512-VPidfvg42fmRih7WsNHXGDRaqslMOLePs+1JdH66wCpODEBpU0FstXvREKG2pJg2Uy4oz3k/ZJI4AFEIbkrt8Q==",
+      "requires": {
+        "atomic-batcher": "^1.0.2",
+        "continuation-local-storage": "^3.2.0",
+        "date-fns": "^1.29.0",
+        "lodash": "^4.17.10",
+        "pkginfo": "^0.4.0",
+        "semver": "^5.3.0",
+        "winston": "^2.2.0"
+      }
+    },
+    "aws-xray-sdk-express": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-1.3.0.tgz",
+      "integrity": "sha512-Pz0uw6EJqmMUwxVx4Mjest5gvu+eWUS3HEfw2HTsOzQpUQ+xnlc50Unf9ilK4Xdf3p8nxN0lV9eIyofugOY6Aw=="
+    },
+    "aws-xray-sdk-mysql": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-mysql/-/aws-xray-sdk-mysql-1.3.0.tgz",
+      "integrity": "sha512-T/nitPlE7ilL99OaZLP5l69Dd9NtasqxMDGlZcV/+vCdSQR4r2fquPYlS+O74BgaH++hEg/hP1y8HvwoxEzpfQ=="
+    },
+    "aws-xray-sdk-postgres": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-postgres/-/aws-xray-sdk-postgres-1.3.0.tgz",
+      "integrity": "sha512-bOWmYXwd39g9cP2UBuPX8buEr4lxFmI2dtx1MXpjkieK0GJPYNm82BPIw5k8qX6adTB3hDZQvHoD98AeKYopng=="
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/DevOps/3_XRay/uni-api/app/package.json
+++ b/DevOps/3_XRay/uni-api/app/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-xray-sdk": "^2.153.0",
+    "aws-sdk": "^2.153.0",
     "aws-xray-sdk": "^1.1.6"
   }
 }

--- a/DevOps/3_XRay/uni-api/buildspec.yml
+++ b/DevOps/3_XRay/uni-api/buildspec.yml
@@ -3,6 +3,9 @@ version: 0.2
 phases:
   install:
     commands:
+      # Install application dependencies
+      - npm install --prefix app
+
       # Install dependencies needed for running tests
       - npm install
 

--- a/DevOps/3_XRay/uni-api/package.json
+++ b/DevOps/3_XRay/uni-api/package.json
@@ -5,9 +5,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {},
-  "scripts": {
-    "postinstall": "cd app && npm install"
-  },
+  "scripts": {},
   "devDependencies": {
     "mocha": "^4.0.1",
     "proxyquire": "^1.8.0"


### PR DESCRIPTION
npm triggering of postinstall script in package.json no longer works to install uni-api application dependencies.  changing approach to use "npm install --prefix" instead.

Credit to @carlosaln for the heads up.  Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
