### PR TITLE
Dataprocessing lambda should use utf8 instead of ascii

### DIFF
--- a/DataProcessing/guide/content/stream-processing.md
+++ b/DataProcessing/guide/content/stream-processing.md
@@ -161,7 +161,7 @@ environment variable with the key `TABLE_NAME` and the value
 
     function buildRequestItems(records) {
       return records.map((record) => {
-        const json = Buffer.from(record.kinesis.data, 'base64').toString('ascii');
+        const json = Buffer.from(record.kinesis.data, 'base64').toString('utf8');
         const item = JSON.parse(json);
 
         return {


### PR DESCRIPTION
If someone sends a unicorn name that has characters outside of ascii then it will result in invalid JSON as the character will not be decoded properly.  This fixes that issue.