### PR TITLE
Issue #190, polyfills build error fix

### DIFF
--- a/MultiRegion/2_UI/package.json
+++ b/MultiRegion/2_UI/package.json
@@ -24,7 +24,7 @@
     "@swimlane/ngx-datatable": "^13.1.0",
     "aws-amplify": "^1.0.11",
     "aws-amplify-angular": "^2.0.3",
-    "core-js": "*",
+    "core-js": "^2.6.11",
     "eslint": "^5.5.0",
     "ng-bootstrap": "*",
     "ngx-facebook": "*",

--- a/MultiRegion/2_UI/tsconfig.json
+++ b/MultiRegion/2_UI/tsconfig.json
@@ -16,6 +16,7 @@
       "es2017",
       "dom"
     ],
-    "module": "es2015"
+    "module": "es2015",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Issue 190

As @yxycman has identified, _polyfills.ts_ references polyfills by version (e.g. /es6), but core-js (as of version 3) no longer breaks out polyfills in that way, which causes the 'Module not found' error. The latest working version can be installed using:

`npm i core-js@"<3.0.0" -D`

(which at the time of writing is 2.6.11).

Ideally all dependencies would be updated. However, to avoid breaking changes the _tsconfig.json_ file has been modified to allow the build to succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
