### PR TITLE
fixed typo for Node 10 and IAM policy name

### DIFF
--- a/Auth/0_GettingStarted/README.md
+++ b/Auth/0_GettingStarted/README.md
@@ -92,11 +92,11 @@ Keep your AWS Cloud9 IDE opened in a tab throughout this workshop as you'll be u
 
 ### Initialize your developer workspace
 
-1. Run the following commands to upgrade your Node.js version to the latest version of Node.js 8. The [AWS Amplify](https://aws-amplify.github.io/) JavaScript library which we will be using requires Node.js 8 or higher.
+1. Run the following commands to upgrade your Node.js version to the latest version of Node.js 10. The [AWS Amplify](https://aws-amplify.github.io/) JavaScript library which we will be using requires Node.js 10 or higher.
 
     ```console
-    nvm i 8
-    nvm alias default 8
+    nvm i 10
+    nvm alias default 10
     ```
 
 2. Install the yarn package manager and website dependencies by running the following commands

--- a/Auth/2_ServerlessAPI/Optional-APIGateway-IAMAuth.md
+++ b/Auth/2_ServerlessAPI/Optional-APIGateway-IAMAuth.md
@@ -58,13 +58,13 @@ In the IAM console, assocate the *WildRydesAPI-StandardUserPolicy* with your Cog
 
 1. Choose **Attach policies**.
 
-1. Search for `WildRydes` and check the box next to the policy named *WildRydesAPI-StandardUserAccess*.
+1. Search for `WildRydes` and check the box next to the policy named *WildRydesAPI-StandardUserPolicy*.
 
 	![Attach API Gateway IAM Policy](../images/iam-cognito-authrole-attach-apigateway-policy.png)
 
 1. Choose **Attach policy**.
 
-1. You should now see the *WildRydesAPI-StandardUserAccess* policy associated with your Cognito IAM auth role.
+1. You should now see the *WildRydesAPI-StandardUserPolicy* policy associated with your Cognito IAM auth role.
 
 	![Permissions after adding IAM policy](../images/iam-cognito-authrole-permissions-after-policy-update.png)
 
@@ -156,4 +156,4 @@ Now that you've deployed the new authorizer configuration to production, all API
 </p></details>
 <br>
 
-If your API now invokes correctly and application funcions as expected summoning unicorns again, you can proceed to the next module, [IAM-based Authorization](../3_IAMAuthorization).
+If your API now invokes correctly and application functions as expected summoning unicorns again, you can proceed to the next module, [IAM-based Authorization](../3_IAMAuthorization).


### PR DESCRIPTION
Auth Workshop: update Node 10 README reference and fix IAM policy name typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
