### PR TITLE
repo url fix; lambda tighten permissions

### DIFF
--- a/MachineLearning/0_Setup/README.md
+++ b/MachineLearning/0_Setup/README.md
@@ -50,7 +50,7 @@ Let's get our code and start working. Inside the terminal:
 
 1. Run the following command to get our code:
     ```
-    git clone https://github.com/jmcwhirter/aws-serverless-workshops/
+    git clone https://github.com/aws-samples/aws-serverless-workshops/
     ```
 1. Navigate to our workshop:
     ```

--- a/MachineLearning/1_DataProcessing/cloudformation/99_complete.yml
+++ b/MachineLearning/1_DataProcessing/cloudformation/99_complete.yml
@@ -33,6 +33,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref IngestUnicornRawDataFunction
       Principal: s3.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
       SourceArn: !Sub "arn:aws:s3:::${AWS::StackName}-databucket-${AWS::AccountId}"
   DataProcessingExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Description of changes:*

Tightening Lambda resource-based policy:
Adding `aws:SourceAccount` to avoid a potential [confused deputy attack](https://en.wikipedia.org/wiki/Confused_deputy_problem). if the S3 bucket is deleted or part of a predictable pattern. Adding an additional condition to explicitly specify the bucket owner's account ID may remediate the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
